### PR TITLE
Wrap long, unbroken text to prevent overflow

### DIFF
--- a/_sass/minima/_base.scss
+++ b/_sass/minima/_base.scss
@@ -34,6 +34,15 @@ body {
   line-height: 140%;
   min-height: 100vh;
   flex-direction: column;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  -ms-word-break: break-all;
+      word-break: break-all;
+      word-break: break-word;
+  -webkit-hyphens: auto;
+     -moz-hyphens: auto;
+      -ms-hyphens: auto;
+          hyphens: auto;
 }
 
 


### PR DESCRIPTION
Some pages contain long URLs, which overflow the main content width, especially on mobile breakpoints. Allowing word breaking in those cases looks nicer. To accomplish that in a cross-browser compatible fashion, I copied a rule set from CSS Tricks:

https://css-tricks.com/snippets/css/prevent-long-urls-from-breaking-out-of-container/